### PR TITLE
* Add finally to connectAndCheckHeaders to ensure entity is consumed.…

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/layer/wms/WMSHttpHelper.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/layer/wms/WMSHttpHelper.java
@@ -36,6 +36,7 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
 import org.geotools.util.logging.Logging;
 import org.geowebcache.GeoWebCacheException;
 import org.geowebcache.io.Resource;
@@ -171,117 +172,123 @@ public class WMSHttpHelper extends WMSSourceHelper {
         int responseLength = 0;
 
         try {
-            method = executeRequest(wmsBackendUrl, wmsParams, backendTimeout, httpRequestMode);
-            responseCode = method.getStatusLine().getStatusCode();
-            if (responseCode == 200) {
-                if (method.getFirstHeader("length") != null) {
-                    responseLength = Integer.parseInt(method.getFirstHeader("length").getValue());
-                } else if (method.getFirstHeader("Content-Length") != null) {
-                    responseLength =
-                            Integer.parseInt(method.getFirstHeader("Content-Length").getValue());
-                } else if (method.getEntity() != null) {
-                    responseLength = Math.toIntExact(method.getEntity().getContentLength());
-                } else {
-                    throw new ServiceException(
-                            "Unable to determine response length from: "
-                                    + wmsBackendUrl.toString());
-                }
-            }
-            // Do not set error at this stage
-        } catch (IOException ce) {
-            if (log.isLoggable(Level.FINE)) {
-                String message = "Error forwarding request " + wmsBackendUrl.toString();
-                log.log(Level.FINE, message, ce);
-            }
-            throw new GeoWebCacheException(ce);
-        }
-        // Check that the response code is okay
-        tileRespRecv.setStatus(responseCode);
-        if (responseCode != 200 && responseCode != 204) {
-            tileRespRecv.setError();
-            throw new ServiceException(
-                    "Unexpected response code from backend: "
-                            + responseCode
-                            + " for "
-                            + wmsBackendUrl.toString());
-        }
-
-        // Check that we're not getting an error MIME back.
-        String responseMime = method.getFirstHeader("Content-Type").getValue();
-        if (responseCode != 204
-                && responseMime != null
-                && !requestMimeType.isCompatible(responseMime)) {
-            String message = null;
-            if (responseMime.equalsIgnoreCase(ErrorMime.vnd_ogc_se_inimage.getFormat())) {
-                // TODO: revisit: I don't understand why it's trying to create a String message
-                // out of an ogc_se_inimage response?
-
-                try (InputStream stream = method.getEntity().getContent()) {
-                    byte[] error = IOUtils.toByteArray(stream);
-                    message = new String(error);
-                } catch (IOException ioe) {
-                    // Do nothing
-                }
-            } else if (responseMime != null
-                    && responseMime.toLowerCase().startsWith("application/vnd.ogc.se_xml")) {
-                try (InputStream stream = method.getEntity().getContent()) {
-                    message = IOUtils.toString(stream, StandardCharsets.UTF_8);
-                } catch (IOException e) {
-                    //
-                }
-            }
-            String msg =
-                    "MimeType mismatch, expected "
-                            + requestMimeType
-                            + " but got "
-                            + responseMime
-                            + " from "
-                            + wmsBackendUrl.toString()
-                            + (message == null ? "" : (":\n" + message));
-            tileRespRecv.setError();
-            tileRespRecv.setErrorMessage(msg);
-            log.warning(msg);
-        }
-
-        // Everything looks okay, try to save expiration
-        if (tileRespRecv.getExpiresHeader() == GWCVars.CACHE_USE_WMS_BACKEND_VALUE) {
-            String expireValue = method.getFirstHeader("Expires").getValue();
-            long expire = ServletUtils.parseExpiresHeader(expireValue);
-            if (expire != -1) {
-                tileRespRecv.setExpiresHeader(expire / 1000);
-            }
-        }
-
-        // Read the actual data
-        if (responseCode != 204) {
-            try (InputStream inStream = method.getEntity().getContent()) {
-                if (inStream == null) {
-                    log.severe("No response for " + method);
-                } else {
-                    try (ReadableByteChannel channel = Channels.newChannel(inStream)) {
-                        target.transferFrom(channel);
-                    }
-                }
-                if (responseLength > 0) {
-                    int readAccu = (int) target.getSize();
-                    if (readAccu != responseLength) {
-                        tileRespRecv.setError();
-                        throw new GeoWebCacheException(
-                                "Responseheader advertised "
-                                        + responseLength
-                                        + " bytes, but only received "
-                                        + readAccu
-                                        + " from "
+            try {
+                method = executeRequest(wmsBackendUrl, wmsParams, backendTimeout, httpRequestMode);
+                responseCode = method.getStatusLine().getStatusCode();
+                if (responseCode == 200) {
+                    if (method.getFirstHeader("length") != null) {
+                        responseLength = Integer.parseInt(method.getFirstHeader("length").getValue());
+                    } else if (method.getFirstHeader("Content-Length") != null) {
+                        responseLength =
+                                Integer.parseInt(method.getFirstHeader("Content-Length").getValue());
+                    } else if (method.getEntity() != null) {
+                        responseLength = Math.toIntExact(method.getEntity().getContentLength());
+                    } else {
+                        throw new ServiceException(
+                                "Unable to determine response length from: "
                                         + wmsBackendUrl.toString());
                     }
                 }
-            } catch (IOException ioe) {
+                // Do not set error at this stage
+            } catch (IOException ce) {
+                if (log.isLoggable(Level.FINE)) {
+                    String message = "Error forwarding request " + wmsBackendUrl.toString();
+                    log.log(Level.FINE, message, ce);
+                }
+                throw new GeoWebCacheException(ce);
+            }
+            // Check that the response code is okay
+            tileRespRecv.setStatus(responseCode);
+            if (responseCode != 200 && responseCode != 204) {
                 tileRespRecv.setError();
-                log.severe(
-                        "Caught IO exception, "
+                throw new ServiceException(
+                        "Unexpected response code from backend: "
+                                + responseCode
+                                + " for "
+                                + wmsBackendUrl.toString());
+            }
+
+            // Check that we're not getting an error MIME back.
+            String responseMime = method.getFirstHeader("Content-Type").getValue();
+            if (responseCode != 204
+                    && responseMime != null
+                    && !requestMimeType.isCompatible(responseMime)) {
+                String message = null;
+                if (responseMime.equalsIgnoreCase(ErrorMime.vnd_ogc_se_inimage.getFormat())) {
+                    // TODO: revisit: I don't understand why it's trying to create a String message
+                    // out of an ogc_se_inimage response?
+
+                    try (InputStream stream = method.getEntity().getContent()) {
+                        byte[] error = IOUtils.toByteArray(stream);
+                        message = new String(error);
+                    } catch (IOException ioe) {
+                        // Do nothing
+                    }
+                } else if (responseMime != null
+                        && responseMime.toLowerCase().startsWith("application/vnd.ogc.se_xml")) {
+                    try (InputStream stream = method.getEntity().getContent()) {
+                        message = IOUtils.toString(stream, StandardCharsets.UTF_8);
+                    } catch (IOException e) {
+                        //
+                    }
+                }
+                String msg =
+                        "MimeType mismatch, expected "
+                                + requestMimeType
+                                + " but got "
+                                + responseMime
+                                + " from "
                                 + wmsBackendUrl.toString()
-                                + " "
-                                + ioe.getMessage());
+                                + (message == null ? "" : (":\n" + message));
+                tileRespRecv.setError();
+                tileRespRecv.setErrorMessage(msg);
+                log.warning(msg);
+            }
+
+            // Everything looks okay, try to save expiration
+            if (tileRespRecv.getExpiresHeader() == GWCVars.CACHE_USE_WMS_BACKEND_VALUE) {
+                String expireValue = method.getFirstHeader("Expires").getValue();
+                long expire = ServletUtils.parseExpiresHeader(expireValue);
+                if (expire != -1) {
+                    tileRespRecv.setExpiresHeader(expire / 1000);
+                }
+            }
+
+            // Read the actual data
+            if (responseCode != 204) {
+                try (InputStream inStream = method.getEntity().getContent()) {
+                    if (inStream == null) {
+                        log.severe("No response for " + method);
+                    } else {
+                        try (ReadableByteChannel channel = Channels.newChannel(inStream)) {
+                            target.transferFrom(channel);
+                        }
+                    }
+                    if (responseLength > 0) {
+                        int readAccu = (int) target.getSize();
+                        if (readAccu != responseLength) {
+                            tileRespRecv.setError();
+                            throw new GeoWebCacheException(
+                                    "Responseheader advertised "
+                                            + responseLength
+                                            + " bytes, but only received "
+                                            + readAccu
+                                            + " from "
+                                            + wmsBackendUrl.toString());
+                        }
+                    }
+                } catch (IOException ioe) {
+                    tileRespRecv.setError();
+                    log.severe(
+                            "Caught IO exception, "
+                                    + wmsBackendUrl.toString()
+                                    + " "
+                                    + ioe.getMessage());
+                }
+            }
+        } finally {
+            if (method != null) {
+                EntityUtils.consumeQuietly(method.getEntity());
             }
         }
     }


### PR DESCRIPTION
… This fixes the issue where the connection is not released when the remote WMS server returns 500,504,400 status code over a period of time and when geowebcache requests for new tiles. This causes all the threads in Tomcat to be used and not released.